### PR TITLE
Fix template compile error

### DIFF
--- a/templates/email/layout.html
+++ b/templates/email/layout.html
@@ -473,7 +473,7 @@
                                     <table border="0" cellpadding="0" cellspacing="0" width="100%" id="templateBody">
                                         <tr>
                                             <td valign="top" class="bodyContent">
-                                                {{{ @content }}}
+                                                {{ content }}
                                             </td>
                                         </tr>
                                     </table>
@@ -494,7 +494,7 @@
                                         </tr>
                                         <tr>
                                             <td valign="top" class="footerContent" style="padding-top:0; padding-bottom:40px;">
-                                            	<a href=\"{{{ pm:unsubscribe }}}\" style=\"text-decoration:none;\">Unsubscribe</a>
+                                            	<a href=\"{{ unsubscribe }}\" style=\"text-decoration:none;\">Unsubscribe</a>
                                             </td>
                                         </tr>
                                     </table>


### PR DESCRIPTION
thread 'main' panicked at 'Unable to compile templates!: Error { kind: Msg("\n* Failed to parse \"templates/email/layout.html\"\n   --> 497:61\n    |\n497 |                                             \t<a href=\\\"{{ pm:unsubscribe }}\\\" style=\\\"text-decoration:none;\\\">Unsubscribe</a>␊\n    |                                             \t               ^---\n    |\n    = expected `or`, `and`, `not`, `<=`, `>=`, `<`, `>`, `==`, `!=`, `+`, `-`, `*`, `/`, `%`, a filter, or a variable end (`}}`)"), source: None }', jelly/src/templates.rs:54:69