### PR TITLE
Update an installation instruction of sqlx-cli to support v0.5.11

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ the interesting parts.
 - Install `sqlx-cli`, with: 
 
 ```
-cargo install sqlx-cli --no-default-features --features postgres
+cargo install sqlx-cli --no-default-features --features native-tls,postgres
 ```
 
 - Edit `.env.example` to use your settings.


### PR DESCRIPTION
## Purpose
Update an installation instruction of `sqlx-cli` to support v0.5.11

## Overview
Installation of `sqlx-cli`, with:
```
cargo install sqlx-cli --no-default-features --features postgres
```
Will fail:
```
✗ cargo install sqlx-cli --no-default-features --features postgres
    Updating crates.io index
  Installing sqlx-cli v0.5.11
   Compiling libc v0.2.121
   Compiling version_check v0.9.4
   Compiling proc-macro2 v1.0.36
   Compiling unicode-xid v0.2.2
   Compiling syn v1.0.90
   Compiling autocfg v1.1.0
   Compiling typenum v1.15.0
   Compiling cfg-if v1.0.0
   Compiling memchr v2.4.1
   Compiling serde_derive v1.0.136
   Compiling futures-core v0.3.21
   Compiling serde v1.0.136
   Compiling parking_lot_core v0.8.5
   Compiling futures-task v0.3.21
   Compiling futures-channel v0.3.21
   Compiling log v0.4.16
   Compiling crossbeam-utils v0.8.8
   Compiling futures-util v0.3.21
   Compiling tinyvec_macros v0.1.0
   Compiling crossbeam-queue v0.3.5
   Compiling serde_json v1.0.79
   Compiling once_cell v1.10.0
   Compiling bitflags v1.3.2
   Compiling pin-project-lite v0.2.8
   Compiling opaque-debug v0.3.0
   Compiling lazy_static v1.4.0
   Compiling scopeguard v1.1.0
   Compiling smallvec v1.8.0
   Compiling futures-sink v0.3.21
   Compiling matches v0.1.9
   Compiling unicode-bidi v0.3.7
   Compiling pin-utils v0.1.0
   Compiling cpufeatures v0.2.2
   Compiling subtle v2.4.1
   Compiling minimal-lexical v0.2.1
   Compiling futures-io v0.3.21
   Compiling percent-encoding v2.1.0
   Compiling ppv-lite86 v0.2.16
   Compiling slab v0.4.6
   Compiling unicode_categories v0.1.1
   Compiling paste v1.0.7
   Compiling nix v0.18.0
   Compiling crc-catalog v1.1.1
   Compiling itoa v1.0.1
   Compiling ryu v1.0.9
   Compiling hex v0.4.3
   Compiling unicode-width v0.1.9
   Compiling base64 v0.13.0
   Compiling sqlx-rt v0.5.11
   Compiling unicode-segmentation v1.9.0
   Compiling cfg-if v0.1.10
error: one of the features ['runtime-actix-native-tls', 'runtime-async-std-native-tls', 'runtime-tokio-native-tls', 'runtime-actix-rustls', 'runtime-async-std-rustls', 'runtime-tokio-rustls'] must be enabled
  --> /Users/kamol.mavlonov/.cargo/registry/src/github.com-1ecc6299db9ec823/sqlx-rt-0.5.11/src/lib.rs:9:1
   |
9  | / compile_error!(
10 | |     "one of the features ['runtime-actix-native-tls', 'runtime-async-std-native-tls', \
11 | |      'runtime-tokio-native-tls', 'runtime-actix-rustls', 'runtime-async-std-rustls', \
12 | |      'runtime-tokio-rustls'] must be enabled"
13 | | );
   | |__^

error: could not compile `sqlx-rt` due to previous error
warning: build failed, waiting for other jobs to finish...
error: failed to compile `sqlx-cli v0.5.11`, intermediate artifacts can be found at `/var/folders/xb/5j8mjkh162gf509skyrss8nc0000gp/T/cargo-installY00Lfl`

Caused by:
  build failed
```